### PR TITLE
Updated page metadata to include in tour

### DIFF
--- a/_tour/abstract-types.md
+++ b/_tour/abstract-types.md
@@ -4,13 +4,14 @@ title: Abstract Types
 
 discourse: true
 
-tutorial: scala-tour
-categories: tour
+partof: scala-tour
 num: 23
 next-page: compound-types
 previous-page: inner-classes
+topics: abstract types
 prerequisite-knowledge: variance, upper-type-bound
 
+redirect_from: "/tutorials/tour/abstract-types.html"
 ---
 
 Traits and abstract classes can have an abstract type member. This means that the concrete implementations define the actual type. Here's an example:


### PR DESCRIPTION
The Traits page wasn't being included in the tour TOC, but was being referenced by the tour pages before and after it, Inner Classes and Compound Types respectively. Updated the page metadata to include it in the tour, and fix the other tags.